### PR TITLE
Create a new unit if one does not exist already

### DIFF
--- a/src/systemctl/systemctl-edit.c
+++ b/src/systemctl/systemctl-edit.c
@@ -571,6 +571,10 @@ int verb_edit(int argc, char *argv[], void *userdata) {
                         r = 0;
         }
 
+        if (arg_new) {
+                printf("%s", arg_template);
+        }
+
 end:
         STRV_FOREACH_PAIR(original, tmp, paths) {
                 (void) unlink(*tmp);

--- a/src/systemctl/systemctl-edit.c
+++ b/src/systemctl/systemctl-edit.c
@@ -404,19 +404,21 @@ static int find_paths_to_edit(sd_bus *bus, char **names, char ***paths) {
                         return r;
 
                 if (!path) {
-                        if (!arg_force) {
-                                log_info("Run 'systemctl edit%s --force --full %s' to create a new unit.",
-                                         arg_scope == LOOKUP_SCOPE_GLOBAL ? " --global" :
-                                         arg_scope == LOOKUP_SCOPE_USER ? " --user" : "",
-                                         *name);
-                                return -ENOENT;
-                        }
+                    char response;
+                    r = ask_char(&response, "yn", "\"%s\" does not exists. Should new unit be created? [(y)es, (n)o] ", *name);
+                    if (r < 0)
+                        return r;
+                    if (response != 'y')
+                        return log_warning_errno(SYNTHETIC_ERRNO(EKEYREJECTED), "Skipped %s unit creation.", *name);
+                    else if (response == 'y') {
+                        arg_full = 1;
 
                         /* Create a new unit from scratch */
                         unit_name = *name;
                         r = unit_file_create_new(&lp, unit_name,
-                                                 arg_full ? NULL : ".d/override.conf",
-                                                 NULL, &new_path, &tmp_path);
+                                arg_full ? NULL : ".d/override.conf",
+                                NULL, &new_path, &tmp_path);
+                    }
                 } else {
                         unit_name = basename(path);
                         /* We follow unit aliases, but we need to propagate the instance */

--- a/src/systemctl/systemctl-util.c
+++ b/src/systemctl/systemctl-util.c
@@ -547,7 +547,7 @@ int unit_find_paths(
                         *ret_dropin_paths = NULL;
         }
 
-        if (r == 0 && !arg_force)
+        if (r == 0 && !arg_force && !arg_new)
                 log_error("No files found for %s.", unit_name);
 
         return r;

--- a/src/systemctl/systemctl.c
+++ b/src/systemctl/systemctl.c
@@ -111,6 +111,8 @@ TimestampStyle arg_timestamp_style = TIMESTAMP_PRETTY;
 bool arg_read_only = false;
 bool arg_mkdir = false;
 bool arg_marked = false;
+bool arg_new = false;
+const char *arg_template = NULL;
 
 STATIC_DESTRUCTOR_REGISTER(arg_types, strv_freep);
 STATIC_DESTRUCTOR_REGISTER(arg_states, strv_freep);
@@ -421,6 +423,7 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                 ARG_READ_ONLY,
                 ARG_MKDIR,
                 ARG_MARKED,
+                ARG_NEW,
         };
 
         static const struct option options[] = {
@@ -481,6 +484,7 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
                 { "read-only",           no_argument,       NULL, ARG_READ_ONLY           },
                 { "mkdir",               no_argument,       NULL, ARG_MKDIR               },
                 { "marked",              no_argument,       NULL, ARG_MARKED              },
+                { "new",                 optional_argument, NULL, ARG_NEW                 },
                 {}
         };
 
@@ -905,6 +909,13 @@ static int systemctl_parse_argv(int argc, char *argv[]) {
 
                 case ARG_MARKED:
                         arg_marked = true;
+                        break;
+
+                case ARG_NEW:
+                        arg_new = true;
+                        arg_template = "default_service.template";
+                        if(optarg)
+                                arg_template = optarg;
                         break;
 
                 case '.':

--- a/src/systemctl/systemctl.h
+++ b/src/systemctl/systemctl.h
@@ -96,6 +96,8 @@ extern TimestampStyle arg_timestamp_style;
 extern bool arg_read_only;
 extern bool arg_mkdir;
 extern bool arg_marked;
+extern bool arg_new;
+extern const char *arg_template;
 
 static inline const char* arg_job_mode(void) {
         return _arg_job_mode ?: "replace";


### PR DESCRIPTION
`systemctl edit unit` invocation is updated to prompt user if new unit should be created, instead of giving message to run `systemctl edit --force --full unit.service` to create new unit.

If unit exists already, override file is created.